### PR TITLE
feat: add goal_pose_setter

### DIFF
--- a/docker/aichallenge/aichallenge_ws/src/aichallenge_submit/goal_pose_setter/CMakeLists.txt
+++ b/docker/aichallenge/aichallenge_ws/src/aichallenge_submit/goal_pose_setter/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.8)
+project(goal_pose_setter)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# find dependencies
+find_package(ament_cmake_auto REQUIRED)
+
+ament_auto_find_build_dependencies()
+
+ament_auto_add_executable(goal_pose_setter_node
+  src/goal_pose_setter_node.cpp
+)
+
+ament_auto_package()

--- a/docker/aichallenge/aichallenge_ws/src/aichallenge_submit/goal_pose_setter/package.xml
+++ b/docker/aichallenge/aichallenge_ws/src/aichallenge_submit/goal_pose_setter/package.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>goal_pose_setter</name>
+  <version>0.0.0</version>
+  <description>TODO: Package description</description>
+  <maintainer email="yhisaki31@gmail.com">hisaki</maintainer>
+  <license>TODO: License declaration</license>
+
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>geometry_msgs</depend>
+  <depend>autoware_adapi_v1_msgs</depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/docker/aichallenge/aichallenge_ws/src/aichallenge_submit/goal_pose_setter/src/goal_pose_setter_node.cpp
+++ b/docker/aichallenge/aichallenge_ws/src/aichallenge_submit/goal_pose_setter/src/goal_pose_setter_node.cpp
@@ -1,0 +1,73 @@
+#include "rclcpp/rclcpp.hpp"
+#include "geometry_msgs/msg/pose_stamped.hpp"
+#include "autoware_adapi_v1_msgs/msg/route_state.hpp"
+
+class GoalPosePublisher : public rclcpp::Node
+{
+    bool stop_streaming_goal_pose_ = false;
+
+public:
+    GoalPosePublisher() : Node("goal_pose_publisher")
+    {
+        auto qos = rclcpp::QoS(rclcpp::KeepLast(10)).reliable();
+        goal_publisher_ = this->create_publisher<geometry_msgs::msg::PoseStamped>("/planning/mission_planning/goal", qos);
+        route_state_subscriber_ = this->create_subscription<autoware_adapi_v1_msgs::msg::RouteState>(
+            "/planning/mission_planning/route_state",
+            rclcpp::QoS(rclcpp::KeepLast(10)).reliable().transient_local(),
+            std::bind(&GoalPosePublisher::route_state_callback, this, std::placeholders::_1));
+        timer_ = this->create_wall_timer(
+            std::chrono::milliseconds(300),
+            std::bind(&GoalPosePublisher::publish_goal_pose, this));
+
+        this->declare_parameter("goal.position.x", 21928.861328125);
+        this->declare_parameter("goal.position.y", 51829.57421875);
+        this->declare_parameter("goal.position.z", 0.0);
+        this->declare_parameter("goal.orientation.x", 0.0);
+        this->declare_parameter("goal.orientation.y", 0.0);
+        this->declare_parameter("goal.orientation.z", 0.6982381759416851);
+        this->declare_parameter("goal.orientation.w", 0.7158655248422209);
+    }
+
+private:
+    void publish_goal_pose()
+    {
+        if (!stop_streaming_goal_pose_)
+        {
+            auto msg = std::make_shared<geometry_msgs::msg::PoseStamped>();
+            msg->header.stamp = this->get_clock()->now();
+            msg->header.frame_id = "map";
+            msg->pose.position.x = this->get_parameter("goal.position.x").as_double();
+            msg->pose.position.y = this->get_parameter("goal.position.y").as_double();
+            msg->pose.position.z = this->get_parameter("goal.position.z").as_double();
+            msg->pose.orientation.x = this->get_parameter("goal.orientation.x").as_double();
+            msg->pose.orientation.y = this->get_parameter("goal.orientation.y").as_double();
+            msg->pose.orientation.z = this->get_parameter("goal.orientation.z").as_double();
+            msg->pose.orientation.w = this->get_parameter("goal.orientation.w").as_double();
+
+            goal_publisher_->publish(*msg);
+            RCLCPP_INFO(this->get_logger(), "Publishing goal pose");
+        }
+    }
+
+    void route_state_callback(const autoware_adapi_v1_msgs::msg::RouteState::SharedPtr msg)
+    {
+        if (msg->state >= autoware_adapi_v1_msgs::msg::RouteState::SET)
+        {
+            stop_streaming_goal_pose_ = true;
+            RCLCPP_INFO(this->get_logger(), "Stop streaming goal pose");
+        }
+    }
+
+    rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr goal_publisher_;
+    // subscribe route state
+    rclcpp::Subscription<autoware_adapi_v1_msgs::msg::RouteState>::SharedPtr route_state_subscriber_;
+    rclcpp::TimerBase::SharedPtr timer_;
+};
+
+int main(int argc, char const *argv[])
+{
+    rclcpp::init(argc, argv);
+    rclcpp::spin(std::make_shared<GoalPosePublisher>());
+    rclcpp::shutdown();
+    return 0;
+}


### PR DESCRIPTION
goal_poseをセットするノードを作成した．

launchファイルに
```
  <node name="goal_pose" pkg="goal_pose_setter" exec="goal_pose_setter_node" output="screen">
    <param name="goal.position.x" value="21928.861328125"/>
    <param name="goal.position.y" value="51829.57421875"/>
    <param name="goal.position.z" value="0.0"/>
    <param name="goal.orientation.x" value="0.0"/>
    <param name="goal.orientation.y" value="0.0"/>
    <param name="goal.orientation.z" value="0.6982381759416851"/>
    <param name="goal.orientation.w" value="0.7158655248422209"/>
  </node>
```
と書けば，起動と同時にgoalが設定され，ルートが計算される．

[Screencast from 11-11-2023 01:04:24 AM.webm](https://github.com/AutomotiveAIChallenge/aichallenge2023-racing/assets/42021302/bbee52e8-f62c-47d7-86a5-7495b533f142)

