### PR TITLE
docs: modified a typo in the autoware startup command.

### DIFF
--- a/documentation/docfx_project/setup/index.md
+++ b/documentation/docfx_project/setup/index.md
@@ -213,7 +213,7 @@ aichallenge2023-racing
    3. コンテナ内部でAutowareの起動
    ```
     cd /aichallenge
-    bash run_awsim.sh 
+    bash run_autoware.sh
    ```
 ### 画面録画の方法
 


### PR DESCRIPTION
Autoware起動のコマンドがAWSIM起動のコマンドになっていたので直しました。

＜訂正前＞
![image](https://github.com/AutomotiveAIChallenge/aichallenge2023-racing/assets/42679530/2f3a592c-731b-4cdc-9b13-0db5b49e0a31)



＜訂正後＞
![image](https://github.com/AutomotiveAIChallenge/aichallenge2023-racing/assets/42679530/53bfc45f-b0df-49dd-9a96-e0cb9d19fedb)
