### PR TITLE
fix: minor updates

### DIFF
--- a/docker/aichallenge/aichallenge_ws/src/aichallenge_launch/config/autoware.rviz
+++ b/docker/aichallenge/aichallenge_ws/src/aichallenge_launch/config/autoware.rviz
@@ -2145,5 +2145,5 @@ Window Geometry:
   Views:
     collapsed: false
   Width: 1920
-  X: 2473
+  X: 0
   Y: 0

--- a/docker/evaluation/Dockerfile
+++ b/docker/evaluation/Dockerfile
@@ -13,7 +13,6 @@ RUN sudo apt install -y git-lfs
 RUN git lfs clone https://github.com/AutomotiveAIChallenge/aichallenge2023-racing /ws/aichallenge2023-racing
 
 # Copy into Container
-COPY mapfile /ws/mapfile
 COPY AWSIM /ws/AWSIM
 COPY aichallenge_submit.tar.gz /ws
 COPY main.bash /ws
@@ -24,8 +23,6 @@ RUN cp -r /ws/AWSIM /aichallenge
 RUN chmod 757 /aichallenge
 RUN rm -rf /aichallenge/aichallenge_ws/src/aichallenge_submit
 RUN tar zxf /ws/aichallenge_submit.tar.gz -C /aichallenge/aichallenge_ws/src
-RUN cp -r /ws/mapfile /aichallenge
-
 
 # Build
 RUN apt-get update

--- a/docker/evaluation/advance_preparations.sh
+++ b/docker/evaluation/advance_preparations.sh
@@ -1,4 +1,3 @@
 mkdir -p output
-cp -r ../aichallenge/mapfile ./
 cp -r ../aichallenge/AWSIM ./
 tar zcvf aichallenge_submit.tar.gz -C ../aichallenge/aichallenge_ws/src aichallenge_submit


### PR DESCRIPTION
- Remove mapfile from evaluation Dockerfile because map was moved to aichallenge_submit_launch/map.
- Fix the X coordinate of autoware.rviz window. (This causes the screen recording to not work on AWS)
- Remove mapfile copying in advance_preparations.sh