### PR TITLE
doc: add autonoma documentation to github page

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,1 @@
 *.pcd filter=lfs diff=lfs merge=lfs -text
-*.csv filter=lfs diff=lfs merge=lfs -text

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # aichallenge2023-for-racing
 
-[![.github/workflows/document.yml](https://github.com/AutomotiveAIChallenge/aichallenge2023-racing/actions/workflows/document.yml/badge.svg?branch=feature%2Fen)](https://github.com/AutomotiveAIChallenge/aichallenge2023-racing/actions/workflows/document.yml)
+[![.github/workflows/document.yml](https://github.com/AutomotiveAIChallenge/aichallenge2023-racing/actions/workflows/document.yml/badge.svg?branch=main)](https://github.com/AutomotiveAIChallenge/aichallenge2023-racing/actions/workflows/document.yml)
 
 &emsp; 本リポジトリでは、2023年度の11月から1月にかけて実施される自動運転AIチャレンジRacing大会(仮称)でご利用いただくドキュメント・ファイルを提供しています。
 

--- a/documentation/docfx_project/rule/index.md
+++ b/documentation/docfx_project/rule/index.md
@@ -39,7 +39,7 @@
 - コース境界から100秒以上離れた場合
 - 走行完了は以下のゴール地点を超えた場合になります。
   sampleは`docker/aichallenge/aichallenge_ws/src/aichallenge_submit/autoware_micro/goal_pose_setter/config/default_goal_pose.param.yaml`にあります。（※launch fileでのyaml fileの指定はされていません）
-  ```
+  ```yaml
     goal.position.x: 21912.0
     goal.position.y: 52267.5
   ```
@@ -67,4 +67,60 @@
 
 ### How to check results
 
-&emsp;シミュレーションの内容と結果は、評価システムから出力されるjsonファイル及びシミュレーションの動画から確認可能とする予定です。追加のアナウンスをお待ちください。
+&emsp; 結果のスコアは`result.json`に送られます。
+#### 結果のログ形式
+&emsp; 結果は`~/awsim-logs/result.json` に以下のフォーマットで出力されます。
+
+```json
+{
+  "rawLapTime": 72.77926,
+  "distanceScore": 457.0,
+  "lapTime": 302.779266,
+  "isLapCompleted": false,
+  "isTimeout": false,
+  "trackLimitsViolation": [
+    19, # out of track less than 2 sec
+    19, # out of track more than 2 sec
+    2,  # out of track less than 5m
+    2,  # out of track more than 5m
+    0   # not used
+  ],
+  "collisionViolation": [
+    0, # collision less than 2 sec
+    0, # collision more than 2 sec
+    0, # not used
+    0  # not used
+  ]
+}
+```
+
+&emsp; また、その他のログとして`~/awsim-logs/verbose_result.json`も以下の形式で出力されます。
+
+```json
+{
+  "rawLapTime": 0.0,
+  "distanceScore": 0.0,
+  "lapTime": 0.0,
+  "isLapCompleted": false,
+  "isTimeout": false,
+  "boundsViolations": [
+    {
+      "distance": 0.3017645,
+      "distanceFromBound": 2.26600266,
+      "duration": 0.0160293132
+    },
+    {
+      "distance": 2.776487,
+      "distanceFromBound": 1.01412094,
+      "duration": 0.0801174641
+    },
+    {
+      "distance": 2.91162729,
+      "distanceFromBound": 1.1498549,
+      "duration": 0.08674298
+    },
+    ....
+  ]
+  "collisionViolations": []
+}
+```

--- a/documentation/docfx_project/setup/index.md
+++ b/documentation/docfx_project/setup/index.md
@@ -321,3 +321,16 @@ aichallenge2023-racing
 rocker --device /dev/dri --x11 --user ... # CPU版
 rocker --device /dev/dri --nvidia --x11 --user ... # GPU版
 ```
+
+### 変更点の取り込み
+
+#### dockerのupdate
+```sh
+docker pull ghcr.io/automotiveaichallenge/aichallenge2023-racing/autoware-universe-no-cuda
+```
+
+#### repositoryのupdate
+```sh
+cd aichallenge2023-racing # path to aichallenge2023-racing
+git pull origin/main
+```

--- a/documentation/docfx_project/toc.yml
+++ b/documentation/docfx_project/toc.yml
@@ -1,15 +1,31 @@
 - name: Top
   href: index.html
 - name: Introduction
-  href: intro/index.html
+  dropdown: true
+  items:
+  - name: introduction
+    href: intro/index.html
+  - name: Vehicle Gallery
+    href: https://autonomalabs.github.io/AWSIM/RacingSim/Gallery/vehicle/
+  - name: Vehicle Dynamics
+    href: https://autonomalabs.github.io/AWSIM/RacingSim/VehicleDynamics/
+  - name: Sensors Gallery
+    href: https://autonomalabs.github.io/AWSIM/RacingSim/Gallery/sensors/
+  - name: Racing Sensors
+    href: https://autonomalabs.github.io/AWSIM/RacingSim/Sensors/
+  - name: ROS2 Interface
+    href: https://autonomalabs.github.io/AWSIM/RacingSim/ROS2Interface/
 - name: Setup
   href: setup/index.html
-- name: Rule
-  href: rule/index.html
-- name: LocalEnvironment
-  href: local/index.html
-- name: OnlineEnvironment
-  href: online/index.html
+- name: Competition
+  dropdown: true
+  items:
+  - name: Rule
+    href: rule/index.html
+  - name: LocalEnvironment
+    href: local/index.html
+  - name: OnlineEnvironment
+    href: online/index.html
 - name: Teams
   href: teams/index.html
 - name: Customizing Autoware

--- a/documentation/docfx_project_en/toc.yml
+++ b/documentation/docfx_project_en/toc.yml
@@ -10,13 +10,13 @@
 #  href: local/index.html
 #- name: OnlineEnvironment
 #  href: online/index.html
-#- name: Teams
-#  href: teams/index.html
+- name: Teams
+  href: ../teams/index.html
 #- name: Customizing Autoware
 #  href: customize/index.html
-#- name: FAQ
-#  href: FAQ/index.html
-#- name: Other
-#  href: other/index.html
+- name: FAQ
+  href: ../FAQ/index.html
+- name: Other
+  href: ../other/index.html
 - name: To Japanese Page
   href: ../index.html


### PR DESCRIPTION
- add doc link to autonoma vehicle & sensor gallery
![image](https://github.com/AutomotiveAIChallenge/aichallenge2023-racing/assets/65527974/71c117af-d9fe-48c3-bb35-674f50073414)


test 方法
https://github.com/AutomotiveAIChallenge/aichallenge2023-racing/tree/main/documentation#ai-challenge-documentation