### PR TITLE
fix(goal_pose_setter): add delay until goal is published

### DIFF
--- a/docker/aichallenge/aichallenge_ws/src/aichallenge_submit/autoware_micro/goal_pose_setter/src/goal_pose_setter_node.cpp
+++ b/docker/aichallenge/aichallenge_ws/src/aichallenge_submit/autoware_micro/goal_pose_setter/src/goal_pose_setter_node.cpp
@@ -26,11 +26,18 @@ public:
         this->declare_parameter("goal.orientation.y", 0.0);
         this->declare_parameter("goal.orientation.z", 0.645336);
         this->declare_parameter("goal.orientation.w", 0.763899);
+
+        delay_count_ = 0;
     }
 
 private:
     void publish_goal_pose()
     {
+        if (delay_count_ <= 10) {
+          ++delay_count_;
+          return;
+        }
+
         if (!stop_streaming_goal_pose_)
         {
             auto msg = std::make_shared<geometry_msgs::msg::PoseStamped>();
@@ -62,6 +69,7 @@ private:
     // subscribe route state
     rclcpp::Subscription<autoware_adapi_v1_msgs::msg::RouteState>::SharedPtr route_state_subscriber_;
     rclcpp::TimerBase::SharedPtr timer_;
+    int delay_count_;
 };
 
 int main(int argc, char const *argv[])


### PR DESCRIPTION
## 概要

ローカル環境で、AWSIMを起動し、Autowareを起動した時、時々（1/3ぐらいの確率）でAutoware側の経路が引かれずに走行が開始されない現象が発生していた．

下記画像みたいにgoal_pose_setterは/planning/mission_planning/goalをpublishし続けるが、/planning/mission_planning/routeが引かれないため、それより下のbehavior_path_plannerやsimple_pure_pursuiteが動かない．

![image](https://github.com/AutomotiveAIChallenge/aichallenge2023-racing/assets/5180742/fcbc8fe7-2fc5-436e-8dc7-25c7b5a20e97)

## 原因

/default_ad_api/node/routingがロードされ準備が整う前にgoal_pose_setterでgoalが指定されると、まだ全てのAPIノードが準備できていないのに、一部のサービスが呼ばれてしまい、結果それに対する応答ができなくなってしまう．

## 対策

goal_pose_setterでgoalをpublishし始めるまで少しの遅延を加える．3秒ほど加えればローカルでは問題なく動いた．

## 確認

- ローカル環境で検証済み
- AWS本番環境でも検証済み