### PR TITLE
doc: update rocker installation

### DIFF
--- a/documentation/docfx_project/setup/index.md
+++ b/documentation/docfx_project/setup/index.md
@@ -115,11 +115,15 @@ sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin 
 # インストールできているかをテスト
 sudo docker run hello-world
 
-# rocker install
-sudo sh -c 'echo "deb http://packages.ros.org/ros2/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
-curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add -
-sudo apt update
-sudo apt-get install python3-rocker
+# rocker install (ros installが初めての方はコメントアウトを外して実行)
+# 以下のinstallが依存関係が最も少ないため推奨
+pip install rocker
+
+# 以下はROS依存があるため非推奨とする
+# sudo sh -c 'echo "deb http://packages.ros.org/ros2/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros2.list'
+# curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add -
+# sudo apt update
+# sudo apt-get install python3-rocker
 
 # gitlfs install
 curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | sudo bash

--- a/documentation/docfx_project/setup/index.md
+++ b/documentation/docfx_project/setup/index.md
@@ -116,6 +116,9 @@ sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin 
 sudo docker run hello-world
 
 # rocker install
+sudo sh -c 'echo "deb http://packages.ros.org/ros2/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
+curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add -
+sudo apt update
 sudo apt-get install python3-rocker
 
 # gitlfs install

--- a/documentation/docfx_project_en/setup/index.md
+++ b/documentation/docfx_project_en/setup/index.md
@@ -108,10 +108,7 @@ sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin 
 sudo docker run hello-world
 
 # rocker install
-sudo sh -c 'echo "deb http://packages.ros.org/ros2/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
-curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add -
-sudo apt update
-sudo apt-get install python3-rocker
+pip install rocker
 
 # gitlfs install
 curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | sudo bash

--- a/documentation/docfx_project_en/setup/index.md
+++ b/documentation/docfx_project_en/setup/index.md
@@ -108,6 +108,9 @@ sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin 
 sudo docker run hello-world
 
 # rocker install
+sudo sh -c 'echo "deb http://packages.ros.org/ros2/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
+curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add -
+sudo apt update
 sudo apt-get install python3-rocker
 
 # gitlfs install


### PR DESCRIPTION
resolve #51 

rocker のinstallに必要な依存関係をまっさらな環境では解決しきれていなかったため推奨install方法を変更した
以下の２つがあったが、pipのほうが依存の解決が簡潔であったため採用した
- Debians
- PIP

なお、rockerではDebiansが推奨されているが、理由の記載がない点は気になる。
PIPのほうがplatform依存が少ないという利点もある。
https://github.com/osrf/rocker?tab=readme-ov-file#installation