### PR TITLE
doc: fix rules page regarding track limits violations

### DIFF
--- a/documentation/docfx_project/rule/index.md
+++ b/documentation/docfx_project/rule/index.md
@@ -83,15 +83,15 @@
   "isLapCompleted": false,
   "isTimeout": false,
   "trackLimitsViolation": [
-    19, # out of track less than 2 sec
-    19, # out of track more than 2 sec
-    2,  # out of track less than 5m
-    2,  # out of track more than 5m
+    19, # Duration of time spent off track is less than 2 seconds. (Minor)
+    19, # Distance from track limit is less than 5 meters. (Minor)
+    2,  # Duration of time spent off track is more than 2 seconds. (Major)
+    2,  # Distance from track limit is more than 5 meters. (Major)
     0   # not used
   ],
   "collisionViolation": [
-    0, # collision less than 2 sec
-    0, # collision more than 2 sec
+    0, # Duration of collision is less than or equal to 2 seconds. (Minor)
+    0, # Duration of collision is more than 2 seconds. (Major)
     0, # not used
     0  # not used
   ]

--- a/documentation/docfx_project_en/rule/index.md
+++ b/documentation/docfx_project_en/rule/index.md
@@ -78,22 +78,20 @@ Below are the violations and their corresponding penalties:
 ```json
 {
   "rawLapTime": 72.77926,
-  "distanceScore": 457.0,
+  "distanceScore": 86.7,
   "lapTime": 302.779266,
   "isLapCompleted": false,
   "isTimeout": false,
   "trackLimitsViolation": [
-    19, # out of track less than 2 sec
-    19, # out of track more than 2 sec
-    2,  # out of track less than 5m
-    2,  # out of track more than 5m
+    19, # Duration of time spent off track is less than 2 seconds. (Minor)
+    19, # Distance from track limit is less than 5 meters. (Minor)
+    2,  # Duration of time spent off track is more than 2 seconds. (Major)
+    2,  # Distance from track limit is more than 5 meters. (Major)
     0   # not used
   ],
   "collisionViolation": [
-    0, # collision less than 2 sec
-    0, #
-
- collision more than 2 sec
+    0, # Duration of collision is less than or equal to 2 seconds. (Minor)
+    0, # Duration of collision is more than 2 seconds. (Major)
     0, # not used
     0  # not used
   ]


### PR DESCRIPTION
- Fix the rules page in the documentation, specifically the section that mentions the format of the `result.json` file.
- Addresses [Ticket (Internal)](https://tier4.atlassian.net/browse/ACFR-142)